### PR TITLE
POC Raspberry Pi cross-compliation

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,20 @@
+[target.armv7-unknown-linux-gnueabihf]
+# Based on https://www.collabora.com/news-and-blog/blog/2020/06/23/cross-building-rust-gstreamer-plugins-for-the-raspberry-pi/
+# but with `RUN apt-get install -y libdbus-1-dev:armhf` thrown in to get the dependency we need.
+#
+# `context` and `dockerfile` rely on my patch to `cross` which I will make a PR for soon.
+# Until that is available, you can comment them out and build the image
+# manually, using:
+#
+#    docker build -t my/buster-gst-armv7-unknown-linux-gnueabihf \
+#        ../cross/docker/ \
+#        -f docker/Dockerfile.buster-gst-armv7-unknown-linux-gnueabihf
+#
+# and then specify
+#
+#     image = "my/buster-gst-armv7-unknown-linux-gnueabihf"
+#
+# instead.
+#
+context = "../cross/docker"
+dockerfile = "Dockerfile.buster-gst-armv7-unknown-linux-gnueabihf"

--- a/Cross.toml
+++ b/Cross.toml
@@ -2,11 +2,10 @@
 # Based on https://www.collabora.com/news-and-blog/blog/2020/06/23/cross-building-rust-gstreamer-plugins-for-the-raspberry-pi/
 # but with `RUN apt-get install -y libdbus-1-dev:armhf` thrown in to get the dependency we need.
 # This image has been pushed to dockerhub.
-image = "alsuren/xiaomi-temp-rpi-builder"
+# image = "alsuren/xiaomi-temp-rpi-builder"
 
 
 # Once https://github.com/rust-embedded/cross/pull/446 gets somewhere, you
 # will be able to use `context` and `dockerfile` to achieve the same result.
-#
-# context = "../cross/docker"
-# dockerfile = "Dockerfile.buster-gst-armv7-unknown-linux-gnueabihf"
+context = "./docker"
+dockerfile = "./docker/Dockerfile.buster-gst-armv7-unknown-linux-gnueabihf"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,20 +1,12 @@
 [target.armv7-unknown-linux-gnueabihf]
 # Based on https://www.collabora.com/news-and-blog/blog/2020/06/23/cross-building-rust-gstreamer-plugins-for-the-raspberry-pi/
 # but with `RUN apt-get install -y libdbus-1-dev:armhf` thrown in to get the dependency we need.
+# This image has been pushed to dockerhub.
+image = "alsuren/xiaomi-temp-rpi-builder"
+
+
+# Once https://github.com/rust-embedded/cross/pull/446 gets somewhere, you
+# will be able to use `context` and `dockerfile` to achieve the same result.
 #
-# `context` and `dockerfile` rely on my patch to `cross` which I will make a PR for soon.
-# Until that is available, you can comment them out and build the image
-# manually, using:
-#
-#    docker build -t my/buster-gst-armv7-unknown-linux-gnueabihf \
-#        ../cross/docker/ \
-#        -f docker/Dockerfile.buster-gst-armv7-unknown-linux-gnueabihf
-#
-# and then specify
-#
-#     image = "my/buster-gst-armv7-unknown-linux-gnueabihf"
-#
-# instead.
-#
-context = "../cross/docker"
-dockerfile = "Dockerfile.buster-gst-armv7-unknown-linux-gnueabihf"
+# context = "../cross/docker"
+# dockerfile = "Dockerfile.buster-gst-armv7-unknown-linux-gnueabihf"

--- a/Dockerfile.buster-gst-armv7-unknown-linux-gnueabihf
+++ b/Dockerfile.buster-gst-armv7-unknown-linux-gnueabihf
@@ -1,0 +1,27 @@
+FROM debian:buster
+
+COPY common.sh /
+RUN /common.sh
+
+COPY cmake.sh /
+RUN /cmake.sh
+
+COPY xargo.sh /
+RUN /xargo.sh
+
+RUN apt-get install --assume-yes --no-install-recommends \
+    g++-arm-linux-gnueabihf \
+    libc6-dev-armhf-cross
+
+RUN dpkg --add-architecture armhf && \
+    apt-get update && \
+    apt-get install -y libgstreamer1.0-dev:armhf libgstreamer-plugins-base1.0-dev:armhf libssl-dev:armhf
+
+RUN apt-get install -y libdbus-1-dev:armhf
+
+ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc \
+    CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc \
+    CXX_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++ \
+    QEMU_LD_PREFIX=/usr/arm-linux-gnueabihf \
+    RUST_TEST_THREADS=1 \
+    PKG_CONFIG_PATH=/usr/lib/arm-linux-gnueabihf/pkgconfig

--- a/docker/Dockerfile.buster-gst-armv7-unknown-linux-gnueabihf
+++ b/docker/Dockerfile.buster-gst-armv7-unknown-linux-gnueabihf
@@ -1,12 +1,14 @@
+FROM alsuren/cross-context:latest as context
+
 FROM debian:buster
 
-COPY common.sh /
+COPY  --from=context common.sh /
 RUN /common.sh
 
-COPY cmake.sh /
+COPY  --from=context cmake.sh /
 RUN /cmake.sh
 
-COPY xargo.sh /
+COPY  --from=context xargo.sh /
 RUN /xargo.sh
 
 RUN apt-get install --assume-yes --no-install-recommends \

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,5 @@
+set -euxo pipefail
+
+time cross build --target armv7-unknown-linux-gnueabihf --release
+time rsync target/armv7-unknown-linux-gnueabihf/release/xiaomi pi@raspberrypi.local:xiaomi
+time ssh pi@raspberrypi.local ./xiaomi

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn main() {
 
     println!();
     
-    let device = BluetoothDevice::new(bt_session, String::from("/org/bluez/hci0/dev_A4_C1_38_64_7E_DB"));
+    let device = BluetoothDevice::new(bt_session, String::from("/org/bluez/hci0/dev_A4_C1_38_1F_00_3F"));
     // let device = BluetoothDevice::new(bt_session, String::from("/org/bluez/hci0/dev_A4_C1_38_15_03_55"));
 
     if let Err(e) = device.connect(10000) {


### PR DESCRIPTION
This Pull request enables cross-compilation to the raspberry pi.

It is a bit of a work in progress, based on a blog post from an ex-colleague of mine (https://www.collabora.com/news-and-blog/blog/2020/06/23/cross-building-rust-gstreamer-plugins-for-the-raspberry-pi/) and some patches that I made to `cross` to make my life easier.

Just sharing this here for visibility at this point. I will keep it updated if my `cross` patches (https://github.com/rust-embedded/cross/pull/446) get anywhere.

If you want to try it out, install `cross` from my branch, using

     cargo install --git=https://github.com/alsuren/cross --branch=docker-build-context

and then build the arm binary for raspberry pi using:

    cross build --target armv7-unknown-linux-gnueabihf --release --verbose

